### PR TITLE
Feat: Block Recovery 

### DIFF
--- a/common/src/main/java/org/west2/clusterio/common/codec/LongDecoder.java
+++ b/common/src/main/java/org/west2/clusterio/common/codec/LongDecoder.java
@@ -1,0 +1,14 @@
+package org.west2.clusterio.common.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+
+import java.util.List;
+
+public class LongDecoder extends ByteToMessageDecoder {
+    @Override
+    protected void decode(ChannelHandlerContext channelHandlerContext, ByteBuf byteBuf, List<Object> list) throws Exception {
+        list.add(byteBuf.readLong());
+    }
+}

--- a/common/src/main/java/org/west2/clusterio/common/codec/LongEncoder.java
+++ b/common/src/main/java/org/west2/clusterio/common/codec/LongEncoder.java
@@ -1,0 +1,12 @@
+package org.west2.clusterio.common.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToByteEncoder;
+
+public class LongEncoder extends MessageToByteEncoder<Long> {
+    @Override
+    protected void encode(ChannelHandlerContext channelHandlerContext, Long aLong, ByteBuf byteBuf) throws Exception {
+        byteBuf.writeLong(aLong);
+    }
+}

--- a/common/src/main/java/org/west2/clusterio/common/constant/Constants.java
+++ b/common/src/main/java/org/west2/clusterio/common/constant/Constants.java
@@ -16,4 +16,10 @@ public class Constants {
     public static final int DEFAULT_NAMENODE_PORT = 9096;
 
     public static final int DEFAULT_DATANODE_PORT = 9098;
+
+    public static final int DEFAULT_TRANSFER_SIZE = 1024;
+
+    public static final String DEFAULT_DATANODE_DIR = "/current/finalized";
+
+    public static final String DEFAULT_DATANODE_STREAM_DIR = "/current/rbw";
 }

--- a/common/src/main/java/org/west2/clusterio/common/constant/Constants.java
+++ b/common/src/main/java/org/west2/clusterio/common/constant/Constants.java
@@ -14,4 +14,6 @@ public class Constants {
     public static final String DEFAULT_POOL = "0";
 
     public static final int DEFAULT_NAMENODE_PORT = 9096;
+
+    public static final int DEFAULT_DATANODE_PORT = 9098;
 }

--- a/common/src/main/java/org/west2/clusterio/common/utils/FileUtil.java
+++ b/common/src/main/java/org/west2/clusterio/common/utils/FileUtil.java
@@ -1,5 +1,7 @@
 package org.west2.clusterio.common.utils;
 
+import java.util.zip.CRC32;
+
 public class FileUtil {
     public static String suffix(String filename){
         StringBuilder builder = new StringBuilder();
@@ -10,5 +12,15 @@ public class FileUtil {
             builder.append(filename.charAt(i));
         }
         return null;
+    }
+    public static boolean validate(byte[] bytes,long checksum){
+        CRC32 crc32 = new CRC32();
+        crc32.update(bytes,0,bytes.length);
+        return crc32.getValue() == checksum;
+    }
+    public static long generate(byte[] bytes){
+        CRC32 crc32 = new CRC32();
+        crc32.update(bytes,0,bytes.length);
+        return crc32.getValue();
     }
 }

--- a/datanode/src/main/java/org/west2/clusterio/datanode/client/DatanodeClient.java
+++ b/datanode/src/main/java/org/west2/clusterio/datanode/client/DatanodeClient.java
@@ -1,6 +1,7 @@
 package org.west2.clusterio.datanode.client;
 
 import io.grpc.Channel;
+import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.NegotiationType;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import org.slf4j.Logger;
@@ -15,6 +16,7 @@ import org.west2.clusterio.common.protocolPB.DatanodeProtocol.RegisterDatanodeRe
 import org.west2.clusterio.common.protocolPB.DatanodeProtocol.HeartbeatResponseProto;
 import org.west2.clusterio.common.protocolPB.service.DatanodeServiceGrpc.DatanodeServiceBlockingStub;
 import org.west2.clusterio.datanode.DatanodeSystem;
+import org.west2.clusterio.datanode.service.transfer.TransferBlock;
 
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -27,12 +29,13 @@ import java.util.concurrent.TimeUnit;
 public class DatanodeClient {
     private static final Logger log = LoggerFactory.getLogger(DatanodeClient.class.getName());
 
-    private Channel channel;
+    private ManagedChannel channel;
     private static final DatanodeClient client = new DatanodeClient();
     private final DatanodeSystem sys = DatanodeSystem.getSystem();
     private ScheduledExecutorService executor ;
     private DatanodeServiceBlockingStub blockingStub;
     private final CommandProcessingThread commandProcessingThread;
+
     private DatanodeClient(){
         this.commandProcessingThread = new CommandProcessingThread();
         commandProcessingThread.start();
@@ -59,14 +62,20 @@ public class DatanodeClient {
         return true;
     }
 
-    private boolean processBlockCmd(BlockCommand cmd){
+    private void processBlockCmd(BlockCommand cmd){
         DatanodeInfo[] targets = cmd.getTargets();
-        for (DatanodeInfo info :targets){
-            String ipAddr = info.getIpAddr();
-            int port = info.getPort();
-
+        Block[] blocks = cmd.getBlocks();
+        for (int i = 0; i < targets.length; i++) {
+            DatanodeInfo target = targets[i];
+            String ipAddr = target.getIpAddr();
+            int port = target.getPort();
+            DatanodeTcpClient tcpClient = new DatanodeTcpClient(ipAddr, port);
+            //TODO get dn's local block by blockID
+            Block block = blocks[i];
+            TransferBlock transferBlock = new TransferBlock(block, TransferBlock.Type.FULL);
+            tcpClient.setBlock(transferBlock);
+            tcpClient.transferBlock();
         }
-        return true;
     }
 
     public void startHeartbeat() {
@@ -130,7 +139,7 @@ public class DatanodeClient {
     }
 
     private BlockReportRequest createFirstBlockReport(){
-        //TODO first block need  scan op's file system to know blocks we have
+        //TODO first block need scan op's file system to know blocks we have
         //For now it just for testing
         return new BlockReportRequest(sys.getReg(),"1",new StorageBlockReport[0],new BlockReportContext(1,1,1));
     }

--- a/datanode/src/main/java/org/west2/clusterio/datanode/client/DatanodeClient.java
+++ b/datanode/src/main/java/org/west2/clusterio/datanode/client/DatanodeClient.java
@@ -6,6 +6,7 @@ import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.west2.clusterio.common.constant.Constants;
+import org.west2.clusterio.common.protocol.Block;
 import org.west2.clusterio.common.protocolPB.DatanodeProtocol.BlockReportResponseProto;
 import org.west2.clusterio.common.protocolPB.DatanodeProtocol.DatanodeCommandProto;
 import org.west2.clusterio.common.protocolPB.service.DatanodeServiceGrpc;
@@ -47,11 +48,26 @@ public class DatanodeClient {
     }
 
     public boolean processCmd(DatanodeCommand cmd){
+        int action = cmd.getAction();
+        switch (action){
+            case DatanodeProtocol.DNA_TRANSFER:
+                processBlockCmd((BlockCommand) cmd);
+                break;
+        }
         //TODO handle the cmd here from daemon thread
         log.info("process CMD");
         return true;
     }
 
+    private boolean processBlockCmd(BlockCommand cmd){
+        DatanodeInfo[] targets = cmd.getTargets();
+        for (DatanodeInfo info :targets){
+            String ipAddr = info.getIpAddr();
+            int port = info.getPort();
+
+        }
+        return true;
+    }
 
     public void startHeartbeat() {
         executor = Executors.newSingleThreadScheduledExecutor();
@@ -74,7 +90,7 @@ public class DatanodeClient {
         //When registration complete start heartbeat
         log.info("Datanode Registration success");
         startHeartbeat();
-        sendFirstBlocReport();
+        sendFirstBlockReport();
     }
 
     public void sendBlockingHeartbeat() throws InterruptedException {
@@ -89,7 +105,7 @@ public class DatanodeClient {
         }
     }
 
-    protected void sendFirstBlocReport(){
+    protected void sendFirstBlockReport(){
         if (blockingStub == null){
             creatBlockingStub();
         }

--- a/datanode/src/main/java/org/west2/clusterio/datanode/client/DatanodeTcpClient.java
+++ b/datanode/src/main/java/org/west2/clusterio/datanode/client/DatanodeTcpClient.java
@@ -1,0 +1,78 @@
+package org.west2.clusterio.datanode.client;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.west2.clusterio.common.codec.LongDecoder;
+import org.west2.clusterio.common.constant.Constants;
+import org.west2.clusterio.common.net.NioTcpClient;
+import org.west2.clusterio.common.utils.StartAndShutdown;
+import org.west2.clusterio.datanode.service.transfer.ClientHandler;
+import org.west2.clusterio.datanode.service.transfer.TransferBlock;
+import org.west2.clusterio.datanode.service.transfer.TransferBlockEncoder;
+
+/**
+ * this class is responsible for actual tcp communication
+ */
+public class DatanodeTcpClient implements StartAndShutdown {
+    private static final Logger log = LoggerFactory.getLogger(DatanodeTcpClient.class);
+    private NioTcpClient tcpClient;
+    private TransferBlock block;
+    private final String ipAddr;
+    private final int port;
+
+    public DatanodeTcpClient(String ipAddr, int port) {
+        this.ipAddr = ipAddr;
+        this.port = port;
+    }
+
+    @Override
+    public void shutdown() throws Exception {
+        if (tcpClient != null){
+            tcpClient.shutdown();
+        }else {
+            throw new RuntimeException("client stop before starting");
+        }
+    }
+
+    @Override
+    public void start() throws Exception {
+        tcpClient = new NioTcpClient(ipAddr, port, new ChannelInitializer<NioSocketChannel>() {
+            @Override
+            protected void initChannel(NioSocketChannel ch) throws Exception {
+                ch.pipeline().addLast(new TransferBlockEncoder());
+                ch.pipeline().addLast(new LongDecoder());
+                ch.pipeline().addLast(new ClientHandler(block));
+            }
+        });
+        tcpClient.start();
+    }
+
+    public void transferBlock(){
+        try {
+            start();
+            shutdown();
+        }catch (RuntimeException e){
+            log.error(e.getMessage());
+        }catch (Exception e){
+            log.warn(e.getMessage());
+        }
+    }
+
+    public TransferBlock getBlock() {
+        return block;
+    }
+
+    public void setBlock(TransferBlock block) {
+        this.block = block;
+    }
+
+    public String getIpAddr() {
+        return ipAddr;
+    }
+
+    public int getPort() {
+        return port;
+    }
+}

--- a/datanode/src/main/java/org/west2/clusterio/datanode/server/DatanodeTcpServer.java
+++ b/datanode/src/main/java/org/west2/clusterio/datanode/server/DatanodeTcpServer.java
@@ -1,0 +1,40 @@
+package org.west2.clusterio.datanode.server;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import org.west2.clusterio.common.codec.LongEncoder;
+import org.west2.clusterio.common.constant.Constants;
+import org.west2.clusterio.common.net.NioTcpServer;
+import org.west2.clusterio.common.utils.StartAndShutdown;
+import org.west2.clusterio.datanode.service.transfer.ServerHandler;
+import org.west2.clusterio.datanode.service.transfer.TransferBlockDecoder;
+
+public class DatanodeTcpServer implements StartAndShutdown {
+    private NioTcpServer tcpServer;
+    @Override
+    public void shutdown() throws Exception {
+        if (tcpServer != null){
+            tcpServer.shutdown();
+        }else {
+            throw new RuntimeException("server stop before starting");
+        }
+    }
+
+    @Override
+    public void start() throws Exception {
+        tcpServer = new NioTcpServer(Constants.DEFAULT_DATANODE_PORT, new ChannelInitializer<NioSocketChannel>() {
+            @Override
+            protected void initChannel(NioSocketChannel ch) throws Exception {
+                ch.pipeline().addLast(new TransferBlockDecoder());
+                ch.pipeline().addLast(new LongEncoder());
+                ch.pipeline().addLast(new ServerHandler());
+            }
+        });
+        try {
+            tcpServer.start();
+        }catch (Exception e){
+            e.printStackTrace();
+            throw e;
+        }
+    }
+}

--- a/datanode/src/main/java/org/west2/clusterio/datanode/service/transfer/ClientHandler.java
+++ b/datanode/src/main/java/org/west2/clusterio/datanode/service/transfer/ClientHandler.java
@@ -1,0 +1,66 @@
+package org.west2.clusterio.datanode.service.transfer;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.west2.clusterio.common.constant.Constants;
+import org.west2.clusterio.common.protocol.Block;
+import org.west2.clusterio.common.utils.FileUtil;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+
+public class ClientHandler extends ChannelInboundHandlerAdapter {
+    private volatile long start = 0;
+    private volatile int l = Constants.DEFAULT_TRANSFER_SIZE;
+    private RandomAccessFile randomAccessFile;
+    private TransferBlock block;
+    private TransferBlock byteBlock = new TransferBlock(TransferBlock.Type.BYTES);
+    public ClientHandler(TransferBlock block) {
+        this.block = block;
+    }
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        String path = Constants.DEFAULT_DATANODE_DIR+File.separator+ Block.BLOCK_FILE_PREFIX+block.getBlockId();
+        randomAccessFile = new RandomAccessFile(new File(path),"r");
+        System.out.println("flush");
+        try {
+            ctx.writeAndFlush(block);
+        }catch (Exception e){
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        start = (Long) msg;
+        System.out.println("start: "+start);
+        if (start == block.getNumBytes()){
+            randomAccessFile.close();
+            ctx.close();
+            System.out.println("读完");
+            return;
+        }
+        if (start != -1){
+            if (randomAccessFile.length() - start < Constants.DEFAULT_TRANSFER_SIZE){
+                l =(int) (randomAccessFile.length() - start);
+            }
+            byte[] bytes = new byte[l];
+            randomAccessFile.seek(start);
+            randomAccessFile.read(bytes);
+            long checksum = FileUtil.generate(bytes);
+            byteBlock.setBytes(bytes);
+            byteBlock.setChecksum(checksum);
+            try {
+                ctx.writeAndFlush(byteBlock);
+            }catch (Exception e){
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        cause.printStackTrace();
+        ctx.close();
+    }
+}

--- a/datanode/src/main/java/org/west2/clusterio/datanode/service/transfer/ServerHandler.java
+++ b/datanode/src/main/java/org/west2/clusterio/datanode/service/transfer/ServerHandler.java
@@ -1,0 +1,68 @@
+package org.west2.clusterio.datanode.service.transfer;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.west2.clusterio.common.constant.Constants;
+import org.west2.clusterio.common.protocol.Block;
+import org.west2.clusterio.common.utils.FileUtil;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+
+public class ServerHandler extends ChannelInboundHandlerAdapter {
+    private static final Logger log = LoggerFactory.getLogger("Server Handler");
+    private long byteRead;
+    private volatile long start = 0;
+    private long totalLength = 0;
+    private String filename = Block.BLOCK_FILE_PREFIX;
+    private RandomAccessFile rw = null;
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        TransferBlock block = (TransferBlock) msg;
+        if (block.getType() ==  TransferBlock.Type.FULL){
+            totalLength = block.getNumBytes();
+//            System.out.println("总长度："+totalLength);
+//            System.out.println("millis: "+ block.getGenerationStamp());
+            filename += block.getBlockId();
+            String path = Constants.DEFAULT_DATANODE_STREAM_DIR + File.separator +filename;
+            File file = new File(path);
+            rw = new RandomAccessFile(file,"rw");
+//            System.out.println("Server flush start: "+start);
+            ctx.writeAndFlush(start);
+        }else if (block.getType() == TransferBlock.Type.BYTES){
+            rw.seek(start);
+            byte[] bytes = block.getBytes();
+            byteRead = bytes.length;
+            if (FileUtil.validate(bytes,block.getChecksum())){
+                start = start + byteRead;
+                rw.write(bytes);
+            }
+            ctx.writeAndFlush(start);
+            if (start == totalLength){
+                moveComplete(filename);
+//                System.out.println("Finish");
+                rw.close();
+                ctx.close();
+            }
+        }
+    }
+
+    public void moveComplete(String filename){
+        File endDirection = new File(Constants.DEFAULT_DATANODE_DIR);
+        if (!endDirection.exists()){
+            endDirection.mkdir();
+        }
+
+        File start = new File(Constants.DEFAULT_DATANODE_STREAM_DIR+filename);
+        File end = new File(endDirection + File.separator + start.getName());
+        try {
+            if (!start.renameTo(end)){
+                log.warn("Failed to move file when completed");
+            }
+        }catch (Exception e){
+            log.error(e.getMessage());
+        }
+    }
+}

--- a/datanode/src/main/java/org/west2/clusterio/datanode/service/transfer/TransferBlock.java
+++ b/datanode/src/main/java/org/west2/clusterio/datanode/service/transfer/TransferBlock.java
@@ -1,0 +1,60 @@
+package org.west2.clusterio.datanode.service.transfer;
+
+import org.west2.clusterio.common.protocol.Block;
+
+/**
+ * The class is used to transfer blocks between dns
+ */
+public class TransferBlock extends Block {
+    private Type type;
+    private byte[] bytes;
+    private long checksum;
+
+    public TransferBlock(Type type) {
+        this.type = type;
+    }
+    public TransferBlock(Block block,Type type) {
+        super(block);
+        this.type = type;
+    }
+    public enum Type{
+        BYTES((byte)1),FULL((byte)2);
+        private byte type;
+
+        Type(byte type) {
+            this.type = type;
+        }
+        public int getValue() {
+            return type;
+        }
+        public static Type get(byte type) {
+            for (Type value : values()) {
+                if (value.type == type) {
+                    return value;
+                }
+            }
+
+            throw new RuntimeException("unsupported type: " + type);
+        }
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public byte[] getBytes() {
+        return bytes;
+    }
+
+    public void setBytes(byte[] bytes) {
+        this.bytes = bytes;
+    }
+
+    public long getChecksum() {
+        return checksum;
+    }
+
+    public void setChecksum(long checksum) {
+        this.checksum = checksum;
+    }
+}

--- a/datanode/src/main/java/org/west2/clusterio/datanode/service/transfer/TransferBlockDecoder.java
+++ b/datanode/src/main/java/org/west2/clusterio/datanode/service/transfer/TransferBlockDecoder.java
@@ -1,0 +1,26 @@
+package org.west2.clusterio.datanode.service.transfer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+
+import java.util.List;
+
+public class TransferBlockDecoder extends ByteToMessageDecoder {
+    @Override
+    protected void decode(ChannelHandlerContext channelHandlerContext, ByteBuf byteBuf, List<Object> list) throws Exception {
+        TransferBlock.Type type = TransferBlock.Type.get(byteBuf.readByte());
+        TransferBlock block = new TransferBlock(type);
+        if (type == TransferBlock.Type.FULL){
+            block.setBlockId(byteBuf.readLong());
+            block.setGenerationStamp(byteBuf.readLong());
+            block.setNumBytes(byteBuf.readLong());
+        }else {
+            block.setChecksum(byteBuf.readLong());
+            byte[] bytes = new byte[byteBuf.readableBytes()];
+            byteBuf.readBytes(bytes);
+            block.setBytes(bytes);
+        }
+        list.add(block);
+    }
+}

--- a/datanode/src/main/java/org/west2/clusterio/datanode/service/transfer/TransferBlockEncoder.java
+++ b/datanode/src/main/java/org/west2/clusterio/datanode/service/transfer/TransferBlockEncoder.java
@@ -1,0 +1,20 @@
+package org.west2.clusterio.datanode.service.transfer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToByteEncoder;
+
+public class TransferBlockEncoder extends MessageToByteEncoder<TransferBlock> {
+    @Override
+    protected void encode(ChannelHandlerContext channelHandlerContext, TransferBlock block, ByteBuf byteBuf) throws Exception {
+        byteBuf.writeByte(block.getType().getValue());
+        if (block.getType() == TransferBlock.Type.FULL) {
+            byteBuf.writeLong(block.getBlockId());
+            byteBuf.writeLong(block.getGenerationStamp());
+            byteBuf.writeLong(block.getNumBytes());
+        } else {
+            byteBuf.writeLong(block.getChecksum());
+            byteBuf.writeBytes(block.getBytes());
+        }
+    }
+}


### PR DESCRIPTION
## Namenode Side

1. As one block's replication number below the replication factor(e.g. datanode down), namenode will detect this situation
2. Namenode rearrange the blocks and send BlockCommand to datanode through heartbeat

## Datanode Side

1. datanode received BlockCommand and bulid up connection to another datanodes
2. each block will be divided into slices(1k data with 8 bytes checksum) during transmission
3. streaming file will be stored at /current/rbw and renamed to /current/finalized when complete